### PR TITLE
Fix test-conda-env-name to activate foo env in entrypoint

### DIFF
--- a/test-conda-env-name/Dockerfile
+++ b/test-conda-env-name/Dockerfile
@@ -1,6 +1,6 @@
 FROM coiled/default:latest
 
-RUN conda create -n foo
+RUN conda create -n foo -c conda-forge python=3.8
 
 ENV TINI_VERSION v0.16.1
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini

--- a/test-conda-env-name/entrypoint.sh
+++ b/test-conda-env-name/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-echo "conda activate foo" >> ~/.bashrc
+# Activate the "foo" conda environment
+. /opt/conda/etc/profile.d/conda.sh
+conda activate foo
+
 exec "$@"


### PR DESCRIPTION
Previous this wouldn't point to Python in the "foo" environment

```bash
$ docker run -it conda-env-test:latest which python
/opt/conda/envs/foo/bin/python
```