### PR TITLE
Stay NB_USER in notebook image

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -24,6 +24,3 @@ RUN conda install --yes \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \
     && find /opt/conda/lib/python*/site-packages/bokeh/server/static -type f,l -name '*.js' -not -name '*.min.js' -delete \
     && rm -rf /opt/conda/pkgs
-
-# So we can chmod postbuild scripts
-USER root


### PR DESCRIPTION
I want to test this out to see if it fixes some permissions issues we are seeing when attempting to install packages into a software environment that use the `notebook` image for its base image 